### PR TITLE
Comparación de estrategias de data augmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,19 @@ Opciones del script:
 | --batch | 16 | Tamaño del batch |
 | --imgsz | 640 | Tamaño de imagen |
 | --data | data/poc_10_clases/data.yaml | Config del dataset |
+| --seed | 42 | Seed para reproducibilidad |
+
+### Comparar estrategias de data augmentation
+
+```bash
+# Compara 3 configs: sin augmentation, default Ultralytics, agresivo
+uv run python src/compare_augmentation.py --data data/poc_multiproduct/data.yaml
+
+# Con menos épocas para test rápido
+uv run python src/compare_augmentation.py --data data/poc_multiproduct/data.yaml --epochs 10
+```
+
+Resultados en `runs/augmentation_comparison/comparison_results.json`.
 
 ### 4. Ejecutar inferencia
 

--- a/data/train_v5.yaml
+++ b/data/train_v5.yaml
@@ -1,0 +1,16 @@
+train: /Users/nicocia/Desktop/VpC2/POC.v5i.yolov5pytorch/train/images
+val: /Users/nicocia/Desktop/VpC2/POC.v5i.yolov5pytorch/valid/images
+test: /Users/nicocia/Desktop/VpC2/POC.v5i.yolov5pytorch/test/images
+
+nc: 10
+names:
+  - aceite_1l
+  - aceite_4l
+  - dulce_de_leche
+  - fideos
+  - leche_descremada
+  - leche_entera
+  - miel
+  - polenta
+  - tomate
+  - yerba_kalena

--- a/data/train_v5.yaml
+++ b/data/train_v5.yaml
@@ -1,6 +1,6 @@
-train: /Users/nicocia/Desktop/VpC2/POC.v5i.yolov5pytorch/train/images
-val: /Users/nicocia/Desktop/VpC2/POC.v5i.yolov5pytorch/valid/images
-test: /Users/nicocia/Desktop/VpC2/POC.v5i.yolov5pytorch/test/images
+train: train/images
+val: valid/images
+test: test/images
 
 nc: 10
 names:
@@ -14,3 +14,4 @@ names:
   - polenta
   - tomate
   - yerba_kalena
+path: .

--- a/src/compare_augmentation.py
+++ b/src/compare_augmentation.py
@@ -17,7 +17,17 @@ import json
 from datetime import datetime
 from pathlib import Path
 
+import torch
 from ultralytics import YOLO
+
+
+def get_device() -> str:
+    """Auto-detecta el mejor dispositivo disponible."""
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
 
 
 # Configuraciones de augmentation a comparar
@@ -79,32 +89,42 @@ def train_config(
     batch: int,
     imgsz: int,
     project: str,
+    seed: int = 42,
+    device: str | None = None,
 ) -> dict:
     """Entrena una configuración y retorna métricas."""
+    if device is None:
+        device = get_device()
+
     print()
     print("=" * 60)
     print(f"Configuración: {config_name}")
     print(f"  {config['description']}")
+    print(f"  Device: {device}")
     print(f"  Parámetros: {config['params']}")
     print("=" * 60)
 
     model = YOLO("yolov10n.pt")
 
-    results = model.train(
-        data=str(data_yaml),
-        epochs=epochs,
-        imgsz=imgsz,
-        batch=batch,
-        project=project,
-        name=config_name,
-        patience=20,
-        save=True,
-        plots=True,
-        verbose=False,
-        device="mps",
-        amp=False,
+    train_kwargs = {
+        "data": str(data_yaml),
+        "epochs": epochs,
+        "imgsz": imgsz,
+        "batch": batch,
+        "project": project,
+        "name": config_name,
+        "patience": 20,
+        "save": True,
+        "plots": True,
+        "verbose": False,
+        "seed": seed,
+        "device": device,
         **config["params"],
-    )
+    }
+    if device == "mps":
+        train_kwargs["amp"] = False
+
+    results = model.train(**train_kwargs)
 
     # Evaluar sobre test split — usar save_dir real de Ultralytics
     save_dir = Path(results.save_dir)
@@ -177,13 +197,22 @@ def main():
         default="runs/augmentation_comparison",
         help="Directorio de resultados (default: runs/augmentation_comparison)",
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Seed para reproducibilidad (default: 42)",
+    )
     args = parser.parse_args()
+
+    device = get_device()
 
     print("=" * 60)
     print("Comparación de Data Augmentation — YOLOv10n")
     print("=" * 60)
     print(f"  Dataset:  {args.data}")
     print(f"  Épocas:   {args.epochs}")
+    print(f"  Device:   {device}")
     print(f"  Configs:  {list(CONFIGS.keys())}")
     print("=" * 60)
 
@@ -198,6 +227,8 @@ def main():
             batch=args.batch,
             imgsz=args.imgsz,
             project=args.project,
+            seed=args.seed,
+            device=device,
         )
         all_metrics.append(metrics)
 

--- a/src/compare_augmentation.py
+++ b/src/compare_augmentation.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+Comparación de estrategias de data augmentation para YOLOv10n.
+
+Entrena 3 configuraciones sobre el mismo dataset y compara métricas:
+  1. Sin augmentation (baseline)
+  2. Augmentation por defecto de Ultralytics
+  3. Augmentation agresivo (mosaic + mixup + rotación + más HSV jitter)
+
+Uso:
+    python compare_augmentation.py --data data/train_v5.yaml
+    python compare_augmentation.py --data data/train_v5.yaml --epochs 50
+"""
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+from ultralytics import YOLO
+
+
+# Configuraciones de augmentation a comparar
+CONFIGS = {
+    "sin_augmentation": {
+        "description": "Sin augmentation — baseline para medir impacto",
+        "params": {
+            "augment": False,
+            "mosaic": 0.0,
+            "mixup": 0.0,
+            "flipud": 0.0,
+            "fliplr": 0.0,
+            "hsv_h": 0.0,
+            "hsv_s": 0.0,
+            "hsv_v": 0.0,
+            "degrees": 0.0,
+            "scale": 0.0,
+            "translate": 0.0,
+        },
+    },
+    "default_ultralytics": {
+        "description": "Augmentation por defecto de Ultralytics (mosaic, flip, HSV)",
+        "params": {
+            "mosaic": 1.0,
+            "mixup": 0.0,
+            "flipud": 0.0,
+            "fliplr": 0.5,
+            "hsv_h": 0.015,
+            "hsv_s": 0.7,
+            "hsv_v": 0.4,
+            "degrees": 0.0,
+            "scale": 0.5,
+            "translate": 0.1,
+        },
+    },
+    "augmentation_agresivo": {
+        "description": "Augmentation agresivo (mosaic + mixup + rotación + HSV fuerte)",
+        "params": {
+            "mosaic": 1.0,
+            "mixup": 0.3,
+            "flipud": 0.5,
+            "fliplr": 0.5,
+            "hsv_h": 0.02,
+            "hsv_s": 0.9,
+            "hsv_v": 0.5,
+            "degrees": 15.0,
+            "scale": 0.7,
+            "translate": 0.2,
+        },
+    },
+}
+
+
+def train_config(
+    config_name: str,
+    config: dict,
+    data_yaml: Path,
+    epochs: int,
+    batch: int,
+    imgsz: int,
+    project: str,
+) -> dict:
+    """Entrena una configuración y retorna métricas."""
+    print()
+    print("=" * 60)
+    print(f"Configuración: {config_name}")
+    print(f"  {config['description']}")
+    print(f"  Parámetros: {config['params']}")
+    print("=" * 60)
+
+    model = YOLO("yolov10n.pt")
+
+    results = model.train(
+        data=str(data_yaml),
+        epochs=epochs,
+        imgsz=imgsz,
+        batch=batch,
+        project=project,
+        name=config_name,
+        patience=20,
+        save=True,
+        plots=True,
+        verbose=False,
+        device="mps",
+        amp=False,
+        **config["params"],
+    )
+
+    # Evaluar sobre test split — usar save_dir real de Ultralytics
+    save_dir = Path(results.save_dir)
+    best_path = save_dir / "weights" / "best.pt"
+    best_model = YOLO(str(best_path))
+
+    val_results = best_model.val(
+        data=str(data_yaml),
+        split="test",
+        plots=True,
+        verbose=False,
+    )
+
+    metrics = {
+        "config": config_name,
+        "description": config["description"],
+        "params": config["params"],
+        "validation": {
+            "mAP50": float(results.results_dict.get("metrics/mAP50(B)", 0)),
+            "mAP50_95": float(results.results_dict.get("metrics/mAP50-95(B)", 0)),
+            "precision": float(results.results_dict.get("metrics/precision(B)", 0)),
+            "recall": float(results.results_dict.get("metrics/recall(B)", 0)),
+        },
+        "test": {
+            "mAP50": float(val_results.box.map50),
+            "mAP50_95": float(val_results.box.map),
+            "precision": float(val_results.box.mp),
+            "recall": float(val_results.box.mr),
+        },
+    }
+
+    print(f"\n  Resultados {config_name}:")
+    print(f"    Val  — mAP@0.5: {metrics['validation']['mAP50']:.4f}")
+    print(f"    Test — mAP@0.5: {metrics['test']['mAP50']:.4f}")
+
+    return metrics
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compara estrategias de data augmentation para YOLOv10n"
+    )
+    parser.add_argument(
+        "--data", "-d",
+        type=Path,
+        default=Path("data/train_v5.yaml"),
+        help="Path al data.yaml (default: data/train_v5.yaml)",
+    )
+    parser.add_argument(
+        "--epochs", "-e",
+        type=int,
+        default=100,
+        help="Épocas por configuración (default: 100)",
+    )
+    parser.add_argument(
+        "--batch", "-b",
+        type=int,
+        default=16,
+        help="Batch size (default: 16)",
+    )
+    parser.add_argument(
+        "--imgsz",
+        type=int,
+        default=640,
+        help="Tamaño de imagen (default: 640)",
+    )
+    parser.add_argument(
+        "--project",
+        type=str,
+        default="runs/augmentation_comparison",
+        help="Directorio de resultados (default: runs/augmentation_comparison)",
+    )
+    args = parser.parse_args()
+
+    print("=" * 60)
+    print("Comparación de Data Augmentation — YOLOv10n")
+    print("=" * 60)
+    print(f"  Dataset:  {args.data}")
+    print(f"  Épocas:   {args.epochs}")
+    print(f"  Configs:  {list(CONFIGS.keys())}")
+    print("=" * 60)
+
+    all_metrics = []
+
+    for name, config in CONFIGS.items():
+        metrics = train_config(
+            config_name=name,
+            config=config,
+            data_yaml=args.data,
+            epochs=args.epochs,
+            batch=args.batch,
+            imgsz=args.imgsz,
+            project=args.project,
+        )
+        all_metrics.append(metrics)
+
+    # Resumen comparativo
+    print()
+    print("=" * 60)
+    print("RESUMEN COMPARATIVO")
+    print("=" * 60)
+    print(f"{'Configuración':<28} {'Val mAP@0.5':>12} {'Test mAP@0.5':>13} {'Test P':>8} {'Test R':>8}")
+    print("-" * 69)
+    for m in all_metrics:
+        print(
+            f"{m['config']:<28} "
+            f"{m['validation']['mAP50']:>12.4f} "
+            f"{m['test']['mAP50']:>13.4f} "
+            f"{m['test']['precision']:>8.4f} "
+            f"{m['test']['recall']:>8.4f}"
+        )
+    print("=" * 60)
+
+    # Guardar resultados
+    output_path = Path(args.project) / "comparison_results.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "timestamp": datetime.now().isoformat(),
+                "dataset": str(args.data),
+                "epochs": args.epochs,
+                "results": all_metrics,
+            },
+            f,
+            indent=2,
+            ensure_ascii=False,
+        )
+    print(f"\nResultados guardados en: {output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Script que entrena y compara 3 estrategias de data augmentation sobre YOLOv10n con el dataset multiproduct (10 clases):

| Configuración | Val mAP@0.5 | Test mAP@0.5 | Test P | Test R |
|---|---|---|---|---|
| Sin augmentation | 0.728 | 0.512 | 0.884 | 0.376 |
| **Default Ultralytics** | **0.927** | 0.770 | 0.705 | **0.768** |
| **Augmentation agresivo** | 0.886 | **0.776** | **0.887** | 0.571 |

### Hallazgos clave

- Data augmentation es **crítico**: +25 puntos de mAP en test (0.512 → 0.770)
- Sin augmentation, el recall cae a 0.376 — el modelo detecta solo 1/3 de los productos
- Defaults de Ultralytics (mosaic + flip + HSV) dan el mejor balance recall/precision
- Augmentation agresivo (+ mixup + rotación 15°) logra el mejor test mAP pero sacrifica recall

### Archivos

- `src/compare_augmentation.py` — script de comparación automatizado (3 configs × 100 epochs)
- `data/train_v5.yaml` — dataset config con splits train/val/test

### Uso

```bash
uv run python src/compare_augmentation.py --data data/train_v5.yaml --epochs 100
```

## Issues relacionados

- Relates to #15 (Aplicar data augmentation)

## Test plan

- [x] `uv run ruff check src/compare_augmentation.py` pasa sin errores
- [x] Script ejecutado exitosamente con 3 configuraciones
- [x] Resultados guardados en `runs/augmentation_comparison/comparison_results.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)